### PR TITLE
Generate ArgoCD Application manifests

### DIFF
--- a/k8s/argocd/applications/nodejs.yaml
+++ b/k8s/argocd/applications/nodejs.yaml
@@ -1,12 +1,13 @@
+# manifests/templates/argocd-app.yaml.j2
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: nodejs-app
+  name: nodejs
   namespace: argocd
 spec:
   project: default
   source:
-    repoURL: https://github.com/{{ github_repository }}
+    repoURL: https://github.com/kbunnyjoel/github-actions-example
     targetRevision: HEAD
     path: apps/nodejs/chart
     helm:


### PR DESCRIPTION
This PR contains ArgoCD Application manifests for newly detected applications.
Each manifest was rendered using the provided Jinja2 template.
Please review the generated files under `k8s/argocd/applications/` before merging.